### PR TITLE
LinebotハンドラーがApplicationServiceに直接依存しないようにリファクタリング

### DIFF
--- a/cloudrun/main.go
+++ b/cloudrun/main.go
@@ -21,16 +21,16 @@ func main() {
 		slog.Error("Failed to create Firestore repository")
 		return
 	}
-
 	app := NewApplicationService(openaiAdaper, firestoreRepo, firestoreRepo)
 
-	linebot, err := NewLinebot(app)
+	linebot, err := NewLinebot()
 	if err != nil {
 		slog.Error("Failed to create Linebot")
 		return
 	}
+	httpHandler := linebot.CreateHandler(app.ReplyWithHistory, app.Unfollow)
 
-	server, err := NewServer(linebot.Handler)
+	server, err := NewServer(httpHandler)
 	if err != nil {
 		slog.Error("Failed to create server")
 		return

--- a/cloudrun/usecase.go
+++ b/cloudrun/usecase.go
@@ -64,6 +64,12 @@ type ChatRepository interface {
 	Archive(ctx context.Context, sid EventSourceID) error
 }
 
+// ChatReplyer チャットの入力に対して返答するワークフローを関数の型で定義する
+type ChatReplyer func(input string, sid EventSourceID) string
+
+// Unfollower フォローを解除されたときのワークフローを関数の型で定義する
+type Unfollower func(sid EventSourceID)
+
 type ApplicationService struct {
 	openai    OpenAI
 	chatRepo  ChatRepository
@@ -77,6 +83,11 @@ func NewApplicationService(openai OpenAI, chatRepo ChatRepository, usageRepo API
 		usageRepo: usageRepo,
 	}
 }
+
+// 各メソッドが定義された関数型を満たしているか検証
+var _ ChatReplyer = (*ApplicationService)(nil).Reply
+var _ ChatReplyer = (*ApplicationService)(nil).ReplyWithHistory
+var _ Unfollower = (*ApplicationService)(nil).Unfollow
 
 func (a *ApplicationService) Reply(input string, sid EventSourceID) string {
 	start := time.Now()


### PR DESCRIPTION
ワークフローを関数型で定義し、Linebotハンドラーはその型に依存するようにすることで、直接ApplicationServiceに依存しないような関係性に修正した。